### PR TITLE
A a new scenario that combines all other scenarios

### DIFF
--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -1,190 +1,169 @@
 import numpy as np
 import random
 import bezier
+import copy
 
 from gym_art.quadrotor_multi.quad_utils import generate_points
 
+QUADS_MODE_LIST = ['static_same_goal', 'static_diff_goal', 'dynamic_same_goal', 'dynamic_diff_goal',
+                             'circular_config', 'ep_lissajous3D', 'ep_rand_bezier', 'swarm_vs_swarm']
+QUADS_FORMATION_LIST = ['circle_xz_vertical', 'circle_yz_vertical', 'circle_horizontal', 'sphere',
+                                  'grid_xz_vertical', 'grid_yz_vertical', 'grid_horizontal']
 
-def create_scenario(quads_mode, envs, pos, settle_count, num_agents, room_dims,
-                    rews_settle_raw, rews_settle, rew_coeff, quads_formation, quads_formation_size):
+
+def create_scenario(quads_mode, envs, num_agents, room_dims, rew_coeff, quads_formation, quads_formation_size):
     cls = eval('Scenario_' + quads_mode)
-    scenario = cls(envs, pos, settle_count, num_agents, room_dims, rews_settle_raw, rews_settle, rew_coeff, quads_formation, quads_formation_size)
+    scenario = cls(envs, num_agents, room_dims, rew_coeff, quads_formation, quads_formation_size)
     return scenario
 
-
 class QuadrotorScenario:
-    def __init__(self, envs, pos, settle_count, num_agents, room_dims,
-                 rews_settle_raw, rews_settle, rew_coeff, quads_formation, quads_formation_size):
+    def __init__(self, envs, num_agents, room_dims, rew_coeff, quads_formation, quads_formation_size):
         self.envs = envs
-        self.pos = pos
-        self.settle_count = settle_count
         self.num_agents = num_agents
         self.room_dims = room_dims
-        self.rews_settle_raw = rews_settle_raw
-        self.rews_settle = rews_settle
         self.rew_coeff = rew_coeff
 
         self.interp = None
 
-        self.cfg_quads_formation = quads_formation
-        self.cfg_quads_formation_size = quads_formation_size
+        # Aux variables for goals of quadrotors
+        self.formation = quads_formation
+        self.formation_size = quads_formation_size
+        self.lowest_formation_size = self.get_lowest_formation_size()
+        self.highest_formation_size = self.get_highest_formation_size()
+        self.formation_center = np.array([0.0, 0.0, 2.0])
 
-        self.formation = self.formation_size = None
+        # Aux variables for settle, mainly for scenarios:
+        # circular configuration && swarm vs swarm
+        self.settle_count = np.zeros(self.num_agents)
+        self.metric_of_settle = self.envs[0].dynamics.arm
 
+        # Generate goals
         self.goals = None
 
-    def get_formation(self):
-        return "circle"
+    def get_lowest_formation_size(self):
+        # The lowest formation size means the formation size that we set, which can control
+        # the distance between the goals of any two quadrotors should be large than 3.0 * quads_arm_size
+        quad_arm_size = self.envs[0].dynamics.arm
+        lowest_formation_size = 3.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
+        return lowest_formation_size
 
-    def get_formation_size(self):
-        return 0.0
-
-    def setup_formation(self):
-        if self.cfg_quads_formation == "default":
-            self.formation = self.get_formation()
-        else:
-            self.formation = self.cfg_quads_formation
-
-        if self.cfg_quads_formation_size < 0:
-            self.formation_size = self.get_formation_size()
-        else:
-            self.formation_size = self.cfg_quads_formation_size
+    def get_highest_formation_size(self):
+        # The highest formation size means the formation size that we set, which can control
+        # the distance between the goals of any two quadrotors should be large than 9.0 * quads_arm_size
+        quad_arm_size = self.envs[0].dynamics.arm
+        highest_formation_size = 9.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
+        return highest_formation_size
 
     def generate_goals(self, num_agents, formation_center=None):
         if formation_center is None:
-            formation_center = np.array([0, 0, 2])
+            formation_center = np.array([0., 0., 2.])
 
-        pi = np.pi
-        goals = []
-        if self.formation == "circle":
-            for i in range(self.num_agents):
-                degree = 2 * pi * i / self.num_agents
-                goal_x = self.formation_size * np.cos(degree)
-                goal_y = self.formation_size * np.sin(degree)
-                goal = formation_center + np.array([goal_x, goal_y, 0])
+        if self.formation.startswith("circle"):
+            pi = np.pi
+            goals = []
+            for i in range(num_agents):
+                degree = 2 * pi * i / num_agents
+                pos_0 = self.formation_size * np.cos(degree)
+                pos_1 = self.formation_size * np.sin(degree)
+                if self.formation.endswith("horizontal"):
+                    goal = np.array([pos_0, pos_1, 0.0])
+                elif self.formation.endswith("xz_vertical"):
+                    goal = np.array([pos_0, 0.0, pos_1])
+                elif self.formation.endswith("yz_vertical"):
+                    goal = np.array([0.0, pos_0, pos_1])
+
                 goals.append(goal)
-            goals = np.array(goals)
 
+            goals = np.array(goals)
+            goals += formation_center
         elif self.formation == "sphere":
-            goals = self.formation_size * np.array(generate_points(self.num_agents)) + formation_center
+            goals = self.formation_size * np.array(generate_points(num_agents)) + formation_center
         elif self.formation.startswith("grid"):
-            dim1 = int(np.floor(np.sqrt(num_agents)))
-            while dim1 > 1:
-                if num_agents % dim1 == 0:
-                    break
-                else:
-                    dim1 -= 1
-            dim2 = num_agents // dim1
+            sqrt_goal_num = np.sqrt(num_agents)
+            grid_number = int(np.ceil(sqrt_goal_num))
 
-            delta1 = self.formation_size / (dim1 - 1) if dim1 != 1 else self.formation_size
-            delta2 = self.formation_size / (dim2 - 1) if dim2 != 1 else self.formation_size
-            for i in range(dim1):
-                for j in range(dim2):
-                    if self.formation.endswith("vertical"):
-                        x = j * delta2 - (self.formation_size / 2)
-                        y = 0.0
-                        z = i * delta1 - (self.formation_size / 2)
-                    elif self.formation.endswith("horizontal"):
-                        x = j * delta2 - (self.formation_size / 2)
-                        y = i * delta1 - (self.formation_size / 2)
-                        z = 0.0
-                    else:
-                        raise NotImplementedError()
+            goals = []
+            for i in range(num_agents):
+                pos_0 = self.formation_size * int(i / grid_number)
+                pos_1 = self.formation_size * (i % grid_number)
+                if self.formation.endswith("horizontal"):
+                    goal = np.array([pos_0, pos_1, 0.0])
+                elif self.formation.endswith("xz_vertical"):
+                    goal = np.array([pos_0, 0.0, pos_1])
+                elif self.formation.endswith("yz_vertical"):
+                    goal = np.array([0.0, pos_0, pos_1])
 
-                    goal = np.array([x, y, z]) + formation_center
-                    goals.append(goal)
+                goals.append(goal)
+
             goals = np.array(goals)
-
-
+            mean_pos = np.mean(goals, axis=0)
+            goals -= mean_pos
+            goals += formation_center
+            goals = np.array(goals)
         else:
             raise NotImplementedError("Unknown formation")
 
         return goals
 
-    def init_goals(self):
-        self.setup_formation()
-
-        self.goals = self.generate_goals(self.num_agents)
-
-    def step(self, infos, rewards):
+    def step(self, infos, rewards, pos):
         raise NotImplementedError("Implemented in a specific scenario")
 
-
-class Scenario_circular_config(QuadrotorScenario):
-    def get_formation_size(self):
-        return 0.5
-
-    def step(self, infos, rewards):
-        for i, e in enumerate(self.envs):
-            dist = np.linalg.norm(self.pos[i] - e.goal)
-            if abs(dist) < 0.05:
-                self.settle_count[i] += 1
-            else:
-                self.settle_count = np.zeros(self.num_agents)
-
-        # drones settled at the goal for 1 sec
-        control_step_for_one_sec = int(self.envs[0].control_freq)
-        tmp_count = self.settle_count >= control_step_for_one_sec
-        if all(tmp_count):
-            np.random.shuffle(self.goals)
-            for i, env in enumerate(self.envs):
-                env.goal = self.goals[i]
-                # Add settle rewards
-                self.rews_settle_raw[i] = control_step_for_one_sec
-                self.rews_settle[i] = self.rew_coeff["quadsettle"] * self.rews_settle_raw[i]
-                rewards[i] += self.rews_settle[i]
-                infos[i]["rewards"]["rew_quadsettle"] = self.rews_settle[i]
-                infos[i]["rewards"]["rewraw_quadsettle"] = self.rews_settle_raw[i]
-
-            self.rews_settle = np.zeros(self.num_agents)
-            self.rews_settle_raw = np.zeros(self.num_agents)
-            self.settle_count = np.zeros(self.num_agents)
+    def reset(self):
+        # Generate goals
+        self.goals = self.generate_goals(self.num_agents)
 
 
-class Scenario_static_goal(QuadrotorScenario):
-    def get_formation(self):
-        return 'circle'
+class QuadrotorScenario_Static_Goal(QuadrotorScenario):
+    def step(self, infos, rewards, pos):
+        return infos, rewards
 
-    def get_formation_size(self):
-        return 0.0
+class Scenario_static_same_goal(QuadrotorScenario_Static_Goal):
+    # TODO: Maybe try increasing the difficuly by changing the pos of formation_center
+    def future_func(self):
+        pass
+    def reset(self):
+        self.formation_size = 0.0
+        # Generate goals
+        self.goals = self.generate_goals(self.num_agents)
 
-    def step(self, infos, rewards):
+class Scenario_static_diff_goal(QuadrotorScenario_Static_Goal):
+    # TODO: Maybe try increasing the difficuly by changing the pos of formation_center
+    def future_func(self):
         pass
 
-
-class Scenario_dynamic_goal(QuadrotorScenario):
-    def get_formation(self):
-        return 'circle'
-
-    def get_formation_size(self):
-        return 0.0
-
-    def step(self, infos, rewards):
+class QuadrotorScenario_Dynamic_Goal(QuadrotorScenario):
+    def step(self, infos, rewards, pos):
         tick = self.envs[0].tick
         # teleport every 5 secs
         control_step_for_five_sec = int(5.0 * self.envs[0].control_freq)
         if tick % control_step_for_five_sec == 0 and tick > 0:
             box_size = self.envs[0].box
-            x = (random.random() * 2 - 1) * box_size
-            y = (random.random() * 2 - 1) * box_size
-            z = random.random() * 2 * box_size
-            if z < 0.25:
-                z = 0.25
-
-            goal = [[x, y, z] for i in range(self.num_agents)]
-            self.goals = np.array(goal)
-
+            x, y = np.random.uniform(low=-box_size, high=box_size, size=(2,)) + self.formation_center[:2]
+            z = np.random.uniform(low=-0.5 * box_size, high=0.5 * box_size) + self.formation_center[2]
+            z = max(0.25, z)
+            self.formation_center = np.array([x, y, z])
+            self.goals = self.generate_goals(num_agents=self.num_agents, formation_center=self.formation_center)
             for i, env in enumerate(self.envs):
                 env.goal = self.goals[i]
 
+        return infos, rewards
+
+class Scenario_dynamic_same_goal(QuadrotorScenario_Dynamic_Goal):
+    # TODO: Maybe try increasing the difficuly by changing the pos of formation_center
+    def future_func(self):
+        pass
+
+    def reset(self):
+        self.formation_size = 0.0
+        # Generate goals
+        self.goals = self.generate_goals(self.num_agents)
+
+class Scenario_dynamic_diff_goal(QuadrotorScenario_Dynamic_Goal):
+    # TODO: Maybe try increasing the difficuly by changing the pos of formation_center
+    def future_func(self):
+        pass
 
 class Scenario_ep_lissajous3D(QuadrotorScenario):
-    def get_formation(self):
-        return 'circle'
-
-    def get_formation_size(self):
-        return 0.0
-
     # Based on https://mathcurve.com/courbes3d.gb/lissajous3d/lissajous3d.shtml
     @staticmethod
     def lissajous3D(tick, a=0.03, b=0.01, c=0.01, n=2, m=2, phi=90, psi=90):
@@ -193,27 +172,21 @@ class Scenario_ep_lissajous3D(QuadrotorScenario):
         z = c * np.cos(m * tick + psi)
         return x, y, z
 
-    def step(self, infos, rewards):
+    def step(self, infos, rewards, pos):
         control_freq = self.envs[0].control_freq
         tick = self.envs[0].tick / control_freq
         x, y, z = self.lissajous3D(tick)
-        goal_x, goal_y, goal_z = self.goals[0][0], self.goals[0][1], self.goals[0][2]
+        goal_x, goal_y, goal_z = self.goals[0]
         x_new, y_new, z_new = x + goal_x, y + goal_y, z + goal_z
-        goal = [[x_new, y_new, z_new] for i in range(self.num_agents)]
-        goal = np.array(goal)
+        self.goals = np.array([[x_new, y_new, z_new] for i in range(self.num_agents)])
 
         for i, env in enumerate(self.envs):
-            env.goal = goal[i]
+            env.goal = self.goals[i]
 
+        return infos, rewards
 
 class Scenario_ep_rand_bezier(QuadrotorScenario):
-    def get_formation(self):
-        return 'circle'
-
-    def get_formation_size(self):
-        return 0.0
-
-    def step(self, infos, rewards):
+    def step(self, infos, rewards, pos):
         # randomly sample new goal pos in free space and have the goal move there following a bezier curve
         tick = self.envs[0].tick
         control_freq = self.envs[0].control_freq
@@ -233,7 +206,8 @@ class Scenario_ep_rand_bezier(QuadrotorScenario):
                     [room_dims[0] / 2, room_dims[1] / 2, room_dims[2]])
                 new_pos = np.random.uniform(low=-high, high=high, size=(2, 3)).reshape(3,
                                                                                        2)  # need an intermediate point for  a deg=2 curve
-                new_pos = new_pos * np.random.randint(min_dist, max_dist + 1) / np.linalg.norm(new_pos, axis=0)  # add some velocity randomization = random magnitude * unit direction
+                new_pos = new_pos * np.random.randint(min_dist, max_dist + 1) / np.linalg.norm(new_pos,
+                                                                                               axis=0)  # add some velocity randomization = random magnitude * unit direction
                 new_pos = self.goals[0].reshape(3, 1) + new_pos
                 lower_bound = np.expand_dims(low, axis=1)
                 upper_bound = np.expand_dims(high, axis=1)
@@ -246,54 +220,162 @@ class Scenario_ep_rand_bezier(QuadrotorScenario):
             self.interp = curve.evaluate_multi(pts)
             # self.interp = np.clip(self.interp, a_min=np.array([0,0,0.2]).reshape(3,1), a_max=high.reshape(3,1)) # want goal clipping to be slightly above the floor
         if tick % control_steps != 0 and tick > 1:
-            goal = self.interp[:, t]
-            self.goals = self.generate_goals(self.num_agents, np.array(goal))
+            self.goals = np.array([self.interp[:, t] for _ in range(self.num_agents)])
 
             for i, env in enumerate(self.envs):
                 env.goal = self.goals[i]
 
+        return infos, rewards
 
-class Scenario_swarm_vs_swarm(QuadrotorScenario):
-    def formation_centers(self):
-        goal_1 = np.array([0.0, 0.0, 2.0])
-        goal_2 = np.array([0.0, 1.5, 2.0])
-        return goal_1, goal_2
+class QuadrotorScenario_Swap_Goals(QuadrotorScenario):
+    def update_goals(self):
+        raise NotImplementedError("Implemented in a specific scenario")
 
-    def create_grids(self, goal1_center, goal2_center):
-        goals_1 = self.generate_goals(self.num_agents // 2, goal1_center)
-        goals_2 = self.generate_goals(self.num_agents // 2, goal2_center)
-        return goals_1, goals_2
+    def post_process(self):
+        raise NotImplementedError("Implemented in a specific scenario")
 
-
-    def init_goals(self):
-        goal_1, goal_2 = self.formation_centers()
-        self.setup_formation()
-        goals_1, goals_2 = self.create_grids(goal_1, goal_2)
-        self.goals = np.concatenate([goals_1, goals_2])
-
-
-    def get_formation(self):
-        return 'grid_vertical'
-
-    def get_formation_size(self):
-        return 1.0
-
-    def step(self, infos, rewards):
-        tick = self.envs[0].tick
-        control_step_for_five_sec = int(5.0 * self.envs[0].control_freq)
-        # Switch every 5th second
-        if tick % control_step_for_five_sec == 0 and tick > 0:
-            goal_1, goal_2 = self.formation_centers()
-            goals_1, goals_2 = self.create_grids(goal_1, goal_2)
-            mid = self.num_agents // 2
-            # Reverse every 10th second
-            if tick % (control_step_for_five_sec * 2) == 0:
-                for i, env in enumerate(self.envs[:mid]):
-                    env.goal = goals_1[i]
-                for i, env in enumerate(self.envs[mid:]):
-                    env.goal = goals_2[i]
+    def step(self, infos, rewards, pos):
+        for i, e in enumerate(self.envs):
+            dist = np.linalg.norm(pos[i] - e.goal)
+            if abs(dist) < self.metric_of_settle:
+                self.settle_count[i] += 1
             else:
-                for i, env in enumerate(self.envs[:mid]):
-                    env.goal = goals_2[i]
-                for i, env in enumerate(self.envs[mid:]):
-                    env.goal = goals_1[i]
+                self.settle_count = np.zeros(self.num_agents)
+                break
+
+        # drones settled at the goal for 1 sec
+        control_step_for_one_sec = int(self.envs[0].control_freq)
+        tmp_count = self.settle_count >= control_step_for_one_sec
+        if all(tmp_count):
+            self.update_goals()
+            rews_settle_raw = control_step_for_one_sec
+            rews_settle = self.rew_coeff["quadsettle"] * rews_settle_raw
+            for i, env in enumerate(self.envs):
+                env.goal = self.goals[i]
+                # Add settle rewards
+                rewards[i] += rews_settle
+                infos[i]["rewards"]["rew_quadsettle"] = rews_settle
+                infos[i]["rewards"]["rewraw_quadsettle"] = rews_settle_raw
+
+            self.settle_count = np.zeros(self.num_agents)
+            self.post_process()
+
+        return infos, rewards
+
+class Scenario_circular_config(QuadrotorScenario_Swap_Goals):
+    def update_goals(self):
+        np.random.shuffle(self.goals)
+
+    def post_process(self):
+        pass
+
+class Scenario_swarm_vs_swarm(QuadrotorScenario_Swap_Goals):
+    def formation_centers(self):
+        if self.formation_center is None:
+            self.formation_center = np.array([0., 0., 2.])
+
+        # self.envs[0].box = 2.0
+        box_size = self.envs[0].box
+        dist_low_bound = 4 * self.envs[0].dynamics.arm
+        # Get the 1st goal center
+        x, y = np.random.uniform(low=-box_size, high=box_size, size=(2,)) + self.formation_center[:2]
+        z = np.random.uniform(low=-0.5 * box_size, high=0.5 * box_size) + self.formation_center[2]
+        goal_center_1 = np.array([x, y, z])
+
+        # Get the 2nd goal center
+        goal_center_distance = np.random.uniform(low=box_size/4, high=box_size)
+
+        phi = np.random.uniform(low=-np.pi, high=np.pi)
+        theta = np.random.uniform(low=-0.5 * np.pi, high=0.5 * np.pi)
+        goal_center_2 = goal_center_1 + goal_center_distance * np.array(
+            [np.sin(theta) * np.cos(phi), np.sin(theta) * np.sin(phi), np.cos(theta)])
+
+        diff_x, diff_y, diff_z = goal_center_2 - goal_center_1
+        if self.formation.endswith("horizontal"):
+            if abs(diff_z) < dist_low_bound:
+                goal_center_2[2] = np.sign(diff_z) * dist_low_bound + goal_center_1[2]
+        elif self.formation.endswith("xz_vertical"):
+            if abs(diff_y) < dist_low_bound:
+                goal_center_2[1] = np.sign(diff_y) * dist_low_bound + goal_center_1[1]
+        elif self.formation.endswith("yz_vertical"):
+            if abs(diff_x) < dist_low_bound:
+                goal_center_2[0] = np.sign(diff_x) * dist_low_bound + goal_center_1[0]
+
+        return goal_center_1, goal_center_2
+
+    def create_grids(self, goal_center_1, goal_center_2):
+        self.goals_1 = self.generate_goals(self.num_agents // 2, goal_center_1)
+        self.goals_2 = self.generate_goals(self.num_agents - self.num_agents // 2, goal_center_2)
+        self.goals = np.concatenate([self.goals_1, self.goals_2])
+
+    def update_goals(self):
+        self.goals = np.concatenate([self.goals_2, self.goals_1])
+
+    def post_process(self):
+        # Switch goals
+        tmp_goals_1 = copy.deepcopy(self.goals_1)
+        tmp_goals_2 = copy.deepcopy(self.goals_2)
+        self.goals_1 = tmp_goals_2
+        self.goals_2 = tmp_goals_1
+
+    def reset(self):
+        # Reset the formation size and the goals of swarms
+        goal_center_1, goal_center_2 = self.formation_centers()
+        self.create_grids(goal_center_1, goal_center_2)
+
+
+class Scenario_mix(QuadrotorScenario):
+    def __init__(self, envs, num_agents, room_dims, rew_coeff, quads_formation, quads_formation_size):
+        super().__init__(envs, num_agents, room_dims, rew_coeff, quads_formation, quads_formation_size)
+        quad_arm_size = self.envs[0].dynamics.arm
+        self.swarm_lowest_formation_size = self.get_lowest_formation_size()
+        self.swarm_highest_formation_size = self.get_highest_formation_size()
+        self.quads_formation_and_size_dict = {
+            "static_same_goal": [["circle_horizontal"], [0.0, 0.0]],
+            "dynamic_same_goal": [["circle_horizontal"], [0.0, 0.0]],
+            "static_diff_goal": [QUADS_FORMATION_LIST, [0.01, 10 * quad_arm_size]],
+            "dynamic_diff_goal": [QUADS_FORMATION_LIST, [0.01, 10 * quad_arm_size]],
+            "ep_lissajous3D": [["circle_horizontal"], [0.0, 0.0]],
+            "ep_rand_bezier": [["circle_horizontal"], [0.0, 0.0]],
+            "circular_config": [QUADS_FORMATION_LIST, [self.lowest_formation_size, self.highest_formation_size]],
+            "swarm_vs_swarm": [QUADS_FORMATION_LIST, [self.swarm_lowest_formation_size, self.swarm_highest_formation_size]],
+        }
+
+
+    def get_swarm_lowest_formation_size(self):
+        # The lowest formation size means the formation size that we set, which can control
+        # the distance between the goals of any two quadrotors should be large than 3.0 * quads_arm_size
+        num_agents = self.num_agents // 2
+        quad_arm_size = self.envs[0].dynamics.arm
+        lowest_swarm_formation_size = 3.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)
+        return lowest_swarm_formation_size
+
+    def get_swarm_highest_formation_size(self):
+        # The highest formation size means the formation size that we set, which can control
+        # the distance between the goals of any two quadrotors should be large than 9.0 * quads_arm_size
+        num_agents = self.num_agents // 2
+        quad_arm_size = self.envs[0].dynamics.arm
+        highest_swarm_formation_size = 9.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)
+        return highest_swarm_formation_size
+
+
+    def step(self, infos, rewards, pos):
+        infos, rewards = self.scenario.step(infos=infos, rewards=rewards, pos=pos)
+        return infos, rewards
+
+    def reset(self):
+        # reset mode
+        mode_index = round(np.random.uniform(low=0, high=len(QUADS_MODE_LIST)-1))
+        mode = QUADS_MODE_LIST[mode_index]
+        # reset formation
+        formation_index = round(np.random.uniform(low=0, high=len(self.quads_formation_and_size_dict[mode][0])-1))
+        self.formation = QUADS_FORMATION_LIST[formation_index]
+        # reset formation size
+        formation_size_low, formation_size_high = self.quads_formation_and_size_dict[mode][1]
+        self.formation_size = np.random.uniform(low=formation_size_low, high=formation_size_high)
+
+        self.scenario = create_scenario(quads_mode=mode, envs=self.envs, num_agents=self.num_agents,
+                                        room_dims=self.room_dims, rew_coeff=self.rew_coeff,
+                                        quads_formation=self.formation, quads_formation_size=self.formation_size)
+        self.scenario.reset()
+        self.goals = self.scenario.goals

--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -342,15 +342,20 @@ class Scenario_mix(QuadrotorScenario):
         quad_arm_size = self.envs[0].dynamics.arm
         self.swarm_lowest_formation_size = self.get_lowest_formation_size()
         self.swarm_highest_formation_size = self.get_highest_formation_size()
+        # key: quads_mode
+        # value: 0. formation, 1: formation_low_size, formation_high_size, 2: episode_time, 3: obstacle_mode
+        str_no_obstacles = "no_obstacles"
+        str_dynamic_obstacles = "dynamic"
+        self.obstacle_number = 1
         self.quads_formation_and_size_dict = {
-            "static_same_goal": [["circle_horizontal"], [0.0, 0.0]],
-            "dynamic_same_goal": [["circle_horizontal"], [0.0, 0.0]],
-            "static_diff_goal": [QUADS_FORMATION_LIST, [0.01, 10 * quad_arm_size]],
-            "dynamic_diff_goal": [QUADS_FORMATION_LIST, [0.01, 10 * quad_arm_size]],
-            "ep_lissajous3D": [["circle_horizontal"], [0.0, 0.0]],
-            "ep_rand_bezier": [["circle_horizontal"], [0.0, 0.0]],
-            "circular_config": [QUADS_FORMATION_LIST, [self.lowest_formation_size, self.highest_formation_size]],
-            "swarm_vs_swarm": [QUADS_FORMATION_LIST, [self.swarm_lowest_formation_size, self.swarm_highest_formation_size]],
+            "static_same_goal": [["circle_horizontal"], [0.0, 0.0], 7.0, str_dynamic_obstacles],
+            "dynamic_same_goal": [["circle_horizontal"], [0.0, 0.0], 16.0, str_no_obstacles],
+            "static_diff_goal": [QUADS_FORMATION_LIST, [0.01, 10 * quad_arm_size], 7.0, str_dynamic_obstacles],
+            "dynamic_diff_goal": [QUADS_FORMATION_LIST, [0.01, 10 * quad_arm_size], 16.0, str_no_obstacles],
+            "ep_lissajous3D": [["circle_horizontal"], [0.0, 0.0], 15.0, str_no_obstacles],
+            "ep_rand_bezier": [["circle_horizontal"], [0.0, 0.0], 15.0, str_no_obstacles],
+            "circular_config": [QUADS_FORMATION_LIST, [self.lowest_formation_size, self.highest_formation_size], 15.0, str_no_obstacles],
+            "swarm_vs_swarm": [QUADS_FORMATION_LIST, [self.swarm_lowest_formation_size, self.swarm_highest_formation_size], 15.0, str_no_obstacles],
         }
 
 
@@ -391,3 +396,9 @@ class Scenario_mix(QuadrotorScenario):
                                         quads_formation=self.formation, quads_formation_size=self.formation_size)
         self.scenario.reset()
         self.goals = self.scenario.goals
+        for env in self.envs:
+            # reset episode time
+            env.reset_ep_len(self.quads_formation_and_size_dict[mode][2])
+            # reset obstacle mode and number
+            obstacle_mode = self.quads_formation_and_size_dict[mode][3]
+            env.reset_obstacle_mode(obstacle_mode=obstacle_mode, obstacle_num=self.obstacle_number)

--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -185,6 +185,12 @@ class Scenario_ep_lissajous3D(QuadrotorScenario):
 
         return infos, rewards
 
+    def reset(self):
+        if self.formation_size <= -1.0:
+            self.formation_size = 0.0
+        # Generate goals
+        self.goals = self.generate_goals(self.num_agents)
+
 class Scenario_ep_rand_bezier(QuadrotorScenario):
     def step(self, infos, rewards, pos):
         # randomly sample new goal pos in free space and have the goal move there following a bezier curve
@@ -226,6 +232,12 @@ class Scenario_ep_rand_bezier(QuadrotorScenario):
                 env.goal = self.goals[i]
 
         return infos, rewards
+
+    def reset(self):
+        if self.formation_size <= -1.0:
+            self.formation_size = 0.0
+        # Generate goals
+        self.goals = self.generate_goals(self.num_agents)
 
 class QuadrotorScenario_Swap_Goals(QuadrotorScenario):
     def update_goals(self):

--- a/gym_art/quadrotor_multi/quadrotor_multi.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi.py
@@ -213,7 +213,8 @@ class QuadrotorEnvMulti(gym.Env):
         self.obstacle_settle_count = np.zeros(self.num_agents)
         quads_pos = np.array([e.dynamics.pos for e in self.envs])
         quads_vel = np.array([e.dynamics.vel for e in self.envs])
-        obs = self.obstacles.reset(obs=obs, quads_pos=quads_pos, quads_vel=quads_vel, set_obstacles=self.set_obstacles)
+        if self.obstacle_num > 0:
+            obs = self.obstacles.reset(obs=obs, quads_pos=quads_pos, quads_vel=quads_vel, set_obstacles=self.set_obstacles)
         self.all_collisions = {val: [0.0 for _ in range(len(self.envs))] for val in ['drone', 'ground', 'obstacle']}
         self.scene.reset(tuple(e.goal for e in self.envs), self.all_dynamics(), self.obstacles, self.all_collisions)
 
@@ -297,12 +298,12 @@ class QuadrotorEnvMulti(gym.Env):
         # run the scenario passed to self.quads_mode
         infos, rewards = self.scenario.step(infos=infos, rewards=rewards, pos=self.pos)
 
-        if self.quads_mode == "mix" and self.obstacle_mode == "no_obstacles":
-            tmp_zero_arr = np.array([np.zeros(self.obstacle_obs_len) for _ in range(self.num_agents)])
-            obs = np.concatenate((obs, tmp_zero_arr), axis=1)
+        # For obstacles
+        quads_vel = np.array([e.dynamics.vel for e in self.envs])
+        if self.quads_mode == "mix" and self.obstacle_mode == "no_obstacles" and self.obstacle_num > 0:
+            obs = self.obstacles.step(obs=obs, quads_pos=self.pos, quads_vel=quads_vel, set_obstacles=False)
 
-        if self.obstacle_mode == 'dynamic':
-            quads_vel = np.array([e.dynamics.vel for e in self.envs])
+        if self.obstacle_mode == 'dynamic' and self.obstacle_num > 0:
             tmp_obs = self.obstacles.step(obs=obs, quads_pos=self.pos, quads_vel=quads_vel,
                                           set_obstacles=self.set_obstacles)
 

--- a/gym_art/quadrotor_multi/quadrotor_multi_obstacles.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi_obstacles.py
@@ -28,6 +28,12 @@ class MultiObstacles():
             self.obstacles.append(obstacle)
 
     def reset(self, obs=None, quads_pos=None, quads_vel=None, set_obstacles=False):
+        if set_obstacles is False:
+            quads_num = len(quads_pos)
+            zero_array = np.array([np.zeros(3) for _ in range(quads_num)])
+            obs = np.concatenate((obs, zero_array, zero_array), axis=1)
+            return obs
+
         for obstacle in self.obstacles:
             obstacle.reset(set_obstacle=set_obstacles)
 
@@ -49,8 +55,11 @@ class MultiObstacles():
 
         return obs
 
-    def collision_detection(self, pos_quads=None):
+    def collision_detection(self, pos_quads=None, set_obstacles=False):
         collision_arr = np.zeros((len(self.obstacles), len(pos_quads)))
+        if set_obstacles is False:
+            return collision_arr
+
         for i, obstacle in enumerate(self.obstacles):
             col_arr = obstacle.collision_detection(pos_quads=pos_quads)
             collision_arr[i] = col_arr

--- a/gym_art/quadrotor_multi/quadrotor_multi_obstacles.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi_obstacles.py
@@ -28,10 +28,7 @@ class MultiObstacles():
             self.obstacles.append(obstacle)
 
     def reset(self, obs=None, quads_pos=None, quads_vel=None, set_obstacles=False):
-        if set_obstacles is False:
-            quads_num = len(quads_pos)
-            zero_array = np.array([np.zeros(3) for _ in range(quads_num)])
-            obs = np.concatenate((obs, zero_array, zero_array), axis=1)
+        if self.num_obstacles <= 0:
             return obs
 
         for obstacle in self.obstacles:
@@ -48,10 +45,7 @@ class MultiObstacles():
         # Generate force, mimic force between electron, F = k*q1*q2 / r^2,
         # Here, F = r^2, k = 1, q1 = q2 = 1
         for obstacle in self.obstacles:
-            rel_pos_obstacle_agents, rel_vel_obstacle_agents = obstacle.step(quads_pos=quads_pos, quads_vel=quads_vel,
-                                                                             set_obstacles=set_obstacles)
-
-            obs = np.concatenate((obs, rel_pos_obstacle_agents, rel_vel_obstacle_agents), axis=1)
+            obs = obstacle.step(obs=obs, quads_pos=quads_pos, quads_vel=quads_vel, set_obstacles=set_obstacles)
 
         return obs
 

--- a/gym_art/quadrotor_multi/quadrotor_single.py
+++ b/gym_art/quadrotor_multi/quadrotor_single.py
@@ -969,7 +969,7 @@ class QuadrotorSingle:
         obs_comps = self.obs_repr.split("_")
         if self.swarm_obs and self.num_agents > 1:
             obs_comps = obs_comps + (['rxyz'] + ['rvxyz']) * (self.num_agents-1)
-        if self.obstacle_mode != 'no_obstacles':
+        if self.obstacle_mode != 'no_obstacles' and self.obstacle_num > 0:
             obs_comps = obs_comps + (['roxyz'] + ['rovxyz']) * (self.obstacle_num)
 
         print("Observation components:", obs_comps)

--- a/gym_art/quadrotor_multi/quadrotor_single.py
+++ b/gym_art/quadrotor_multi/quadrotor_single.py
@@ -857,6 +857,14 @@ class QuadrotorSingle:
         #########################################
         self._seed()
 
+    def reset_ep_len(self, ep_time):
+        self.ep_time = ep_time
+        self.ep_len = int(self.ep_time / (self.dt * self.sim_steps))
+
+    def reset_obstacle_mode(self, obstacle_mode, obstacle_num):
+        self.obstacle_mode = obstacle_mode
+        self.obstacle_num = obstacle_num
+
     def save_dyn_params(self, filename):
         import yaml
         with open(filename, 'w') as yaml_file:

--- a/gym_art/quadrotor_multi/quadrotor_single_obstacle.py
+++ b/gym_art/quadrotor_multi/quadrotor_single_obstacle.py
@@ -15,8 +15,8 @@ class SingleObstacle():
         self.size = size
         self.quad_size = quad_size
         self.dt = dt
-        self.pos = None
-        self.vel = None
+        self.pos = np.array([100., 100., -100.])
+        self.vel = np.array([0., 0., 0.])
         self.reset()
 
     def reset(self, set_obstacle=False):

--- a/gym_art/quadrotor_multi/quadrotor_single_obstacle.py
+++ b/gym_art/quadrotor_multi/quadrotor_single_obstacle.py
@@ -15,8 +15,8 @@ class SingleObstacle():
         self.size = size
         self.quad_size = quad_size
         self.dt = dt
-        self.pos = np.zeros(3)
-        self.vel = np.zeros(3)
+        self.pos = None
+        self.vel = None
         self.reset()
 
     def reset(self, set_obstacle=False):
@@ -28,10 +28,16 @@ class SingleObstacle():
             else:
                 pass
         else:
-            self.pos = np.array([20.0, 20.0, 20.0])
-            self.vel = np.array([0., 0., 0.])
+            self.pos = None
+            self.vel = None
 
     def step(self, quads_pos=None, quads_vel=None, set_obstacles=False):
+        if set_obstacles is False:
+            quads_num = len(quads_pos)
+            zero_array = np.array([np.zeros(3) for _ in range(quads_num)])
+            # return rel_pos, rel_vel
+            return zero_array, zero_array
+
         force_pos = 2 * self.goal_central - self.pos
         rel_force_goal = force_pos - self.goal_central
         force_noise = np.random.uniform(low=-0.5 * rel_force_goal, high=0.5 * rel_force_goal)
@@ -45,11 +51,8 @@ class SingleObstacle():
         # Calculate acceleration, F = ma, here, m = 1.0
         acc = force
         # Calculate velocity
-        if set_obstacles:
-            self.vel += self.dt * acc
-        # Calculate pos
-        if set_obstacles:
-            self.pos += self.dt * self.vel
+        self.vel += self.dt * acc
+        self.pos += self.dt * self.vel
 
         # The pos and vel of the obstacle give by the agents
         rel_pos_obstacle_agents = self.pos - quads_pos

--- a/gym_art/quadrotor_multi/quadrotor_single_obstacle.py
+++ b/gym_art/quadrotor_multi/quadrotor_single_obstacle.py
@@ -28,15 +28,20 @@ class SingleObstacle():
             else:
                 pass
         else:
-            self.pos = None
-            self.vel = None
+            self.pos = np.array([100., 100., -100.])
+            self.vel = np.array([0., 0., 0.])
 
-    def step(self, quads_pos=None, quads_vel=None, set_obstacles=False):
-        if set_obstacles is False:
-            quads_num = len(quads_pos)
-            zero_array = np.array([np.zeros(3) for _ in range(quads_num)])
-            # return rel_pos, rel_vel
-            return zero_array, zero_array
+    def update_obs(self, obs=None, quads_pos=None, quads_vel=None):
+        # The pos and vel of the obstacle give by the agents
+        rel_pos_obstacle_agents = self.pos - quads_pos
+        rel_vel_obstacle_agents = self.vel - quads_vel
+        obs = np.concatenate((obs, rel_pos_obstacle_agents, rel_vel_obstacle_agents), axis=1)
+        return obs
+
+    def step(self, obs=None, quads_pos=None, quads_vel=None, set_obstacles=False):
+        if not set_obstacles:
+            obs = self.update_obs(obs=obs, quads_pos=quads_pos, quads_vel=quads_vel)
+            return obs
 
         force_pos = 2 * self.goal_central - self.pos
         rel_force_goal = force_pos - self.goal_central
@@ -50,14 +55,13 @@ class SingleObstacle():
         force = radius * radius * force_direction
         # Calculate acceleration, F = ma, here, m = 1.0
         acc = force
-        # Calculate velocity
+        # Calculate position and velocity
         self.vel += self.dt * acc
         self.pos += self.dt * self.vel
 
-        # The pos and vel of the obstacle give by the agents
-        rel_pos_obstacle_agents = self.pos - quads_pos
-        rel_vel_obstacle_agents = self.vel - quads_vel
-        return rel_pos_obstacle_agents, rel_vel_obstacle_agents
+        obs = self.update_obs(quads_pos=quads_pos, quads_vel=quads_vel)
+
+        return obs
 
     def static_obstacle(self):
         pass

--- a/gym_art/quadrotor_multi/tests/test_multi_env.py
+++ b/gym_art/quadrotor_multi/tests/test_multi_env.py
@@ -1,6 +1,6 @@
 import time
 from unittest import TestCase
-
+import numpy as np
 from gym_art.quadrotor_multi.quadrotor_multi import QuadrotorEnvMulti
 
 
@@ -42,7 +42,11 @@ class TestMultiEnv(TestCase):
 
         for i in range(1000):
             obs, rewards, dones, infos = env.step([env.action_space.sample() for i in range(num_agents)])
-            self.assertIsInstance(obs, list)
+            try:
+                self.assertIsInstance(obs, list)
+            except:
+                self.assertIsInstance(obs, np.ndarray)
+
             self.assertIsInstance(rewards, list)
             self.assertIsInstance(dones, list)
             self.assertIsInstance(infos, list)


### PR DESCRIPTION
 I **refactored** the quadrotor_scenarios.py and add a **new** scenario that combine all other scenarios. And I also adjusted the name of some scenarios, so, please t **DON'T** forget to merge my pull request for sample-factory after you merging this pull request. Besides, I would like to provide more details about quadrotor_scenarios.py. There are 9 scenarios (including the new scenario, which named 'mix'). 
1. The first group of scenarios includes '**static_same_goal**' and '**dynamic_same_goal**', which means that all drones only have one goal, and the goal can be static/dynamic. In this group, formation is not the case, since formation_size=0.0.  
2. The second group of scenarios includes 'static_diff_goal' and 'dynamic_diff_goal', which means that all drones have their own goals, and the goal can be static/dynamic. In this group, there are 7 kinds of **formation**, which named 'circle_xz_vertical', 'circle_yz_vertical', 'circle_horizontal', 'sphere', 'grid_xz_vertical', 'grid_yz_vertical', 'grid_horizontal'. For example, 'circle_xz_vertical' means that the circle is formed on the plane of xz. 
3. The third group of scenarios includes 'circular_config', which means that the goals of all drones would be shuffled once all drones are settled at their own goals for one second, we should notice that I refactored this scenario, and currently, the formation does not only include a circle in horizontal, it also includes circle in xz/yz plane, grid in xz/yz/xy plane, and sphere. In this group, **same as the second group**, there are 7 kinds of formations. 
4.  The fourth group of scenarios includes 'ep_lissajous3D' and 'ep_rand_bezier', which is designed for the pursuit-evasion task. These two scenarios are much more similar to the dynamic_same_goal scenario, and the only difference is the moving trajectory of the goal. I have checked these two scenarios, but since I am not so familiar with the implementation of these two scenarios. Therefore, it would be better if @SumeetBatra could double-check these two scenarios.
5. The fifth group of scenarios includes 'swarm_vs_swarm'. **Same as the second group**, I extend the formation from only grid to circle, sphere and grid.
6. The sixth group of scenarios includes 'mix'. This scenario combines all scenarios that I mentioned above. 