### PR TITLE
Extend obs space to include goal pos info + Changes to quad_scenarios

### DIFF
--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -5,9 +5,8 @@ import copy
 
 from gym_art.quadrotor_multi.quad_utils import generate_points
 
-# QUADS_MODE_LIST = ['static_same_goal', 'static_diff_goal', 'dynamic_same_goal', 'dynamic_diff_goal',
-#                              'circular_config', 'ep_lissajous3D', 'ep_rand_bezier', 'swarm_vs_swarm']
-QUADS_MODE_LIST = ['circular_config']
+QUADS_MODE_LIST = ['static_same_goal', 'static_diff_goal', 'dynamic_same_goal', 'dynamic_diff_goal',
+                             'circular_config', 'ep_lissajous3D', 'ep_rand_bezier', 'swarm_vs_swarm']
 QUADS_FORMATION_LIST = ['circle_xz_vertical', 'circle_yz_vertical', 'circle_horizontal', 'sphere',
                                   'grid_xz_vertical', 'grid_yz_vertical', 'grid_horizontal']
 

--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -246,9 +246,6 @@ class QuadrotorScenario_Swap_Goals(QuadrotorScenario):
     def update_goals(self):
         raise NotImplementedError("Implemented in a specific scenario")
 
-    def post_process(self):
-        raise NotImplementedError("Implemented in a specific scenario")
-
     def step(self, infos, rewards, pos):
         for i, e in enumerate(self.envs):
             dist = np.linalg.norm(pos[i] - e.goal)
@@ -273,7 +270,6 @@ class QuadrotorScenario_Swap_Goals(QuadrotorScenario):
                 infos[i]["rewards"]["rewraw_quadsettle"] = rews_settle_raw
 
             self.settle_count = np.zeros(self.num_agents)
-            self.post_process()
 
         return infos, rewards
 
@@ -282,8 +278,6 @@ class Scenario_circular_config(QuadrotorScenario_Swap_Goals):
     def update_goals(self):
         np.random.shuffle(self.goals)
 
-    def post_process(self):
-        pass
 
 class Scenario_swarm_vs_swarm(QuadrotorScenario_Swap_Goals):
     def formation_centers(self):
@@ -367,8 +361,8 @@ class Scenario_mix(QuadrotorScenario):
         self.quads_formation_and_size_dict = {
             "static_same_goal": [["circle_horizontal"], [0.0, 0.0], 7.0, str_dynamic_obstacles],
             "dynamic_same_goal": [["circle_horizontal"], [0.0, 0.0], 16.0, str_no_obstacles],
-            "static_diff_goal": [QUADS_FORMATION_LIST, [5 * quad_arm_size, 10 * quad_arm_size], 7.0, str_dynamic_obstacles], # [13.8, 46] centimeters
-            "dynamic_diff_goal": [QUADS_FORMATION_LIST, [5 * quad_arm_size, 10 * quad_arm_size], 16.0, str_no_obstacles], # [13.8, 46] centimeters
+            "static_diff_goal": [QUADS_FORMATION_LIST, [5 * quad_arm_size, 10 * quad_arm_size], 7.0, str_dynamic_obstacles], # [23, 46] centimeters
+            "dynamic_diff_goal": [QUADS_FORMATION_LIST, [5 * quad_arm_size, 10 * quad_arm_size], 16.0, str_no_obstacles], # [23, 46] centimeters
             "ep_lissajous3D": [["circle_horizontal"], [0.0, 0.0], 15.0, str_no_obstacles],
             "ep_rand_bezier": [["circle_horizontal"], [0.0, 0.0], 15.0, str_no_obstacles],
             "circular_config": [QUADS_FORMATION_LIST, [self.lowest_formation_size, self.highest_formation_size], 15.0, str_no_obstacles],

--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -42,14 +42,14 @@ class QuadrotorScenario:
 
     def get_lowest_formation_size(self):
         # The lowest formation size means the formation size that we set, which can control
-        # the distance between the goals of any two quadrotors should be large than 3.0 * quads_arm_size
+        # the distance between the goals of any two quadrotors should be large than 4.0 * quads_arm_size
         quad_arm_size = self.envs[0].dynamics.arm # arm length: 4.6 centimeters
         lowest_formation_size = 4.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
         return lowest_formation_size
 
     def get_highest_formation_size(self):
         # The highest formation size means the formation size that we set, which can control
-        # the distance between the goals of any two quadrotors should be large than 9.0 * quads_arm_size
+        # the distance between the goals of any two quadrotors should be large than 12.0 * quads_arm_size
         quad_arm_size = self.envs[0].dynamics.arm # arm length: 4.6 centimeters
         highest_formation_size = 12.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
         return highest_formation_size
@@ -378,7 +378,7 @@ class Scenario_mix(QuadrotorScenario):
 
     def get_swarm_lowest_formation_size(self):
         # The lowest formation size means the formation size that we set, which can control
-        # the distance between the goals of any two quadrotors should be large than 3.0 * quads_arm_size
+        # the distance between the goals of any two quadrotors should be large than 6.0 * quads_arm_size
         num_agents = self.num_agents // 2
         quad_arm_size = self.envs[0].dynamics.arm # 4.6 centimeters
         lowest_swarm_formation_size = 6.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)
@@ -386,7 +386,7 @@ class Scenario_mix(QuadrotorScenario):
 
     def get_swarm_highest_formation_size(self):
         # The highest formation size means the formation size that we set, which can control
-        # the distance between the goals of any two quadrotors should be large than 9.0 * quads_arm_size
+        # the distance between the goals of any two quadrotors should be large than 12.0 * quads_arm_size
         num_agents = self.num_agents // 2
         quad_arm_size = self.envs[0].dynamics.arm # 4.6 centimeters
         highest_swarm_formation_size = 12.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)

--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -358,8 +358,8 @@ class Scenario_mix(QuadrotorScenario):
         self.quads_formation_and_size_dict = {
             "static_same_goal": [["circle_horizontal"], [0.0, 0.0], 7.0, str_dynamic_obstacles],
             "dynamic_same_goal": [["circle_horizontal"], [0.0, 0.0], 16.0, str_no_obstacles],
-            "static_diff_goal": [QUADS_FORMATION_LIST, [3 * quad_arm_size, 10 * quad_arm_size], 7.0, str_dynamic_obstacles], # [13.8, 46] centimeters
-            "dynamic_diff_goal": [QUADS_FORMATION_LIST, [3 * quad_arm_size, 10 * quad_arm_size], 16.0, str_no_obstacles], # [13.8, 46] centimeters
+            "static_diff_goal": [QUADS_FORMATION_LIST, [5 * quad_arm_size, 10 * quad_arm_size], 7.0, str_dynamic_obstacles], # [13.8, 46] centimeters
+            "dynamic_diff_goal": [QUADS_FORMATION_LIST, [5 * quad_arm_size, 10 * quad_arm_size], 16.0, str_no_obstacles], # [13.8, 46] centimeters
             "ep_lissajous3D": [["circle_horizontal"], [0.0, 0.0], 15.0, str_no_obstacles],
             "ep_rand_bezier": [["circle_horizontal"], [0.0, 0.0], 15.0, str_no_obstacles],
             "circular_config": [QUADS_FORMATION_LIST, [self.lowest_formation_size, self.highest_formation_size], 15.0, str_no_obstacles],
@@ -372,7 +372,7 @@ class Scenario_mix(QuadrotorScenario):
         # the distance between the goals of any two quadrotors should be large than 3.0 * quads_arm_size
         num_agents = self.num_agents // 2
         quad_arm_size = self.envs[0].dynamics.arm # 4.6 centimeters
-        lowest_swarm_formation_size = 3.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)
+        lowest_swarm_formation_size = 6.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)
         return lowest_swarm_formation_size
 
     def get_swarm_highest_formation_size(self):
@@ -380,7 +380,7 @@ class Scenario_mix(QuadrotorScenario):
         # the distance between the goals of any two quadrotors should be large than 9.0 * quads_arm_size
         num_agents = self.num_agents // 2
         quad_arm_size = self.envs[0].dynamics.arm # 4.6 centimeters
-        highest_swarm_formation_size = 9.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)
+        highest_swarm_formation_size = 12.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/num_agents) / np.sin(2 * np.pi / num_agents)
         return highest_swarm_formation_size
 
 

--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -5,8 +5,9 @@ import copy
 
 from gym_art.quadrotor_multi.quad_utils import generate_points
 
-QUADS_MODE_LIST = ['static_same_goal', 'static_diff_goal', 'dynamic_same_goal', 'dynamic_diff_goal',
-                             'circular_config', 'ep_lissajous3D', 'ep_rand_bezier', 'swarm_vs_swarm']
+# QUADS_MODE_LIST = ['static_same_goal', 'static_diff_goal', 'dynamic_same_goal', 'dynamic_diff_goal',
+#                              'circular_config', 'ep_lissajous3D', 'ep_rand_bezier', 'swarm_vs_swarm']
+QUADS_MODE_LIST = ['circular_config']
 QUADS_FORMATION_LIST = ['circle_xz_vertical', 'circle_yz_vertical', 'circle_horizontal', 'sphere',
                                   'grid_xz_vertical', 'grid_yz_vertical', 'grid_horizontal']
 
@@ -44,14 +45,14 @@ class QuadrotorScenario:
         # The lowest formation size means the formation size that we set, which can control
         # the distance between the goals of any two quadrotors should be large than 3.0 * quads_arm_size
         quad_arm_size = self.envs[0].dynamics.arm # arm length: 4.6 centimeters
-        lowest_formation_size = 3.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
+        lowest_formation_size = 4.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
         return lowest_formation_size
 
     def get_highest_formation_size(self):
         # The highest formation size means the formation size that we set, which can control
         # the distance between the goals of any two quadrotors should be large than 9.0 * quads_arm_size
         quad_arm_size = self.envs[0].dynamics.arm # arm length: 4.6 centimeters
-        highest_formation_size = 9.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
+        highest_formation_size = 12.0 * quad_arm_size * np.sin(np.pi / 2 - np.pi/self.num_agents) / np.sin(2 * np.pi / self.num_agents)
         return highest_formation_size
 
     def generate_goals(self, num_agents, formation_center=None):

--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -2,13 +2,21 @@ import numpy as np
 import random
 import bezier
 
+from gym_art.quadrotor_multi.quad_utils import generate_points
 
-class QuadrotorScenario():
-    def __init__(self, envs, pos, goal, settle_count, num_agents, room_dims,
-                 rews_settle_raw, rews_settle, rew_coeff):
+
+def create_scenario(quads_mode, envs, pos, settle_count, num_agents, room_dims,
+                    rews_settle_raw, rews_settle, rew_coeff, quads_formation, quads_formation_size):
+    cls = eval('Scenario_' + quads_mode)
+    scenario = cls(envs, pos, settle_count, num_agents, room_dims, rews_settle_raw, rews_settle, rew_coeff, quads_formation, quads_formation_size)
+    return scenario
+
+
+class QuadrotorScenario:
+    def __init__(self, envs, pos, settle_count, num_agents, room_dims,
+                 rews_settle_raw, rews_settle, rew_coeff, quads_formation, quads_formation_size):
         self.envs = envs
         self.pos = pos
-        self.goal = goal
         self.settle_count = settle_count
         self.num_agents = num_agents
         self.room_dims = room_dims
@@ -18,10 +26,66 @@ class QuadrotorScenario():
 
         self.interp = None
 
-    def circular_config(self, infos, rewards):
+        self.cfg_quads_formation = quads_formation
+        self.cfg_quads_formation_size = quads_formation_size
+
+        self.formation = self.formation_size = None
+
+        self.goals = None
+
+    def get_formation(self):
+        return "circle"
+
+    def get_formation_size(self):
+        return 0.0
+
+    def setup_formation(self):
+        if self.cfg_quads_formation == "default":
+            self.formation = self.get_formation()
+        else:
+            self.formation = self.cfg_quads_formation
+
+        if self.cfg_quads_formation_size < 0:
+            self.formation_size = self.get_formation_size()
+        else:
+            self.formation_size = self.cfg_quads_formation_size
+
+    def init_goals(self):
+        self.setup_formation()
+
+        pi = np.pi
+
+        goals = []
+
+        if self.formation == "circle":
+            for i in range(self.num_agents):
+                degree = 2 * pi * i / self.num_agents
+                goal_x = self.formation_size * np.cos(degree)
+                goal_y = self.formation_size * np.sin(degree)
+                goal = [goal_x, goal_y, 2.0]
+                goals.append(goal)
+
+            goals = np.array(goals)
+        elif self.formation == "sphere":
+            goals = self.formation_size * np.array(generate_points(self.num_agents))
+            goals[:, 2] += 2.0
+        else:
+            raise NotImplementedError("Unknown formation")
+
+        self.goals = goals
+
+    def step(self, infos, rewards):
+        raise NotImplementedError("Implemented in a specific scenario")
+
+
+class Scenario_circular_config(QuadrotorScenario):
+    def get_formation_size(self):
+        return 0.5
+
+    def step(self, infos, rewards):
         for i, e in enumerate(self.envs):
             dist = np.linalg.norm(self.pos[i] - e.goal)
-            if abs(dist) < 0.02:
+            if abs(dist) < 0.05:
                 self.settle_count[i] += 1
             else:
                 self.settle_count = np.zeros(self.num_agents)
@@ -30,9 +94,9 @@ class QuadrotorScenario():
         control_step_for_one_sec = int(self.envs[0].control_freq)
         tmp_count = self.settle_count >= control_step_for_one_sec
         if all(tmp_count):
-            np.random.shuffle(self.goal)
+            np.random.shuffle(self.goals)
             for i, env in enumerate(self.envs):
-                env.goal = self.goal[i]
+                env.goal = self.goals[i]
                 # Add settle rewards
                 self.rews_settle_raw[i] = control_step_for_one_sec
                 self.rews_settle[i] = self.rew_coeff["quadsettle"] * self.rews_settle_raw[i]
@@ -44,7 +108,26 @@ class QuadrotorScenario():
             self.rews_settle_raw = np.zeros(self.num_agents)
             self.settle_count = np.zeros(self.num_agents)
 
-    def dynamic_goal(self):
+
+class Scenario_static_goal(QuadrotorScenario):
+    def get_formation(self):
+        return 'circle'
+
+    def get_formation_size(self):
+        return 0.0
+
+    def step(self, infos, rewards):
+        pass
+
+
+class Scenario_dynamic_goal(QuadrotorScenario):
+    def get_formation(self):
+        return 'circle'
+
+    def get_formation_size(self):
+        return 0.0
+
+    def step(self, infos, rewards):
         tick = self.envs[0].tick
         # teleport every 5 secs
         control_step_for_five_sec = int(5.0 * self.envs[0].control_freq)
@@ -56,28 +139,49 @@ class QuadrotorScenario():
             if z < 0.25:
                 z = 0.25
 
-            self.goal = [[x, y, z] for i in range(self.num_agents)]
-            self.goal = np.array(self.goal)
+            goal = [[x, y, z] for i in range(self.num_agents)]
+            self.goals = np.array(goal)
 
             for i, env in enumerate(self.envs):
-                env.goal = self.goal[i]
+                env.goal = self.goals[i]
 
-    def static_goal(self):
-        pass
 
-    def ep_lissajous3D(self):
+class Scenario_ep_lissajous3D(QuadrotorScenario):
+    def get_formation(self):
+        return 'circle'
+
+    def get_formation_size(self):
+        return 0.0
+
+    # Based on https://mathcurve.com/courbes3d.gb/lissajous3d/lissajous3d.shtml
+    @staticmethod
+    def lissajous3D(tick, a=0.03, b=0.01, c=0.01, n=2, m=2, phi=90, psi=90):
+        x = a * np.sin(tick)
+        y = b * np.sin(n * tick + phi)
+        z = c * np.cos(m * tick + psi)
+        return x, y, z
+
+    def step(self, infos, rewards):
         control_freq = self.envs[0].control_freq
         tick = self.envs[0].tick / control_freq
         x, y, z = self.lissajous3D(tick)
-        goal_x, goal_y, goal_z = self.goal[0][0], self.goal[0][1], self.goal[0][2]
+        goal_x, goal_y, goal_z = self.goals[0][0], self.goals[0][1], self.goals[0][2]
         x_new, y_new, z_new = x + goal_x, y + goal_y, z + goal_z
-        self.goal = [[x_new, y_new, z_new] for i in range(self.num_agents)]
-        self.goal = np.array(self.goal)
+        goal = [[x_new, y_new, z_new] for i in range(self.num_agents)]
+        goal = np.array(goal)
 
         for i, env in enumerate(self.envs):
-            env.goal = self.goal[i]
+            env.goal = goal[i]
 
-    def ep_rand_bezier(self):
+
+class Scenario_ep_rand_bezier(QuadrotorScenario):
+    def get_formation(self):
+        return 'circle'
+
+    def get_formation_size(self):
+        return 0.0
+
+    def step(self, infos, rewards):
         # randomly sample new goal pos in free space and have the goal move there following a bezier curve
         tick = self.envs[0].tick
         control_freq = self.envs[0].control_freq
@@ -96,27 +200,34 @@ class QuadrotorScenario():
                     [self.room_dims[0] / 2, self.room_dims[1] / 2, self.room_dims[2]])
                 new_pos = np.random.uniform(low=-high, high=high, size=(2, 3)).reshape(3,
                                                                                        2)  # need an intermediate point for  a deg=2 curve
-                new_pos = new_pos * np.random.randint(min_dist, max_dist + 1) / np.linalg.norm(new_pos,
-                                                                                               axis=0)  # add some velocity randomization = random magnitude * unit direction
-                new_pos = self.goal[0].reshape(3, 1) + new_pos
+                new_pos = new_pos * np.random.randint(min_dist, max_dist + 1) / np.linalg.norm(new_pos, axis=0)  # add some velocity randomization = random magnitude * unit direction
+                new_pos = self.goals[0].reshape(3, 1) + new_pos
                 lower_bound = np.expand_dims(low, axis=1)
                 upper_bound = np.expand_dims(high, axis=1)
                 new_goal_found = (new_pos > lower_bound + 0.5).all() and (
                         new_pos < upper_bound - 0.5).all()  # check bounds that are slightly smaller than the room dims
-            nodes = np.concatenate((self.goal[0].reshape(3, 1), new_pos), axis=1)
+            nodes = np.concatenate((self.goals[0].reshape(3, 1), new_pos), axis=1)
             nodes = np.asfortranarray(nodes)
             pts = np.linspace(0, 1, control_steps)
             curve = bezier.Curve(nodes, degree=2)
             self.interp = curve.evaluate_multi(pts)
             # self.interp = np.clip(self.interp, a_min=np.array([0,0,0.2]).reshape(3,1), a_max=high.reshape(3,1)) # want goal clipping to be slightly above the floor
         if tick % control_steps != 0 and tick > 1:
-            self.goal = [self.interp[:, t] for _ in range(self.num_agents)]
-            self.goal = np.array(self.goal)
+            self.goals = [self.interp[:, t] for _ in range(self.num_agents)]
+            self.goals = np.array(self.goals)
 
             for i, env in enumerate(self.envs):
-                env.goal = self.goal[i]
+                env.goal = self.goals[i]
 
-    def swarm_vs_swarm(self):
+
+class Scenario_swarm_vs_swarm(QuadrotorScenario):
+    def get_formation(self):
+        return 'grid_vertical'
+
+    def get_formation_size(self):
+        return 1.0
+
+    def step(self, infos, rewards):
         tick = self.envs[0].tick
         control_step_for_five_sec = int(5.0 * self.envs[0].control_freq)
         # Switch every 5th second

--- a/gym_art/quadrotor_multi/quadrotor_multi.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi.py
@@ -84,7 +84,7 @@ class QuadrotorEnvMulti(gym.Env):
         else:
             raise NotImplementedError(f'{obs_repr} not supported!')
 
-        self.neighbor_obs_size = 6
+        self.neighbor_obs_size = 9
         self.clip_neighbor_space_length = (num_agents-1) * self.neighbor_obs_size
         self.clip_neighbor_space_min_box = self.observation_space.low[obs_self_size:obs_self_size+self.clip_neighbor_space_length]
         self.clip_neighbor_space_max_box = self.observation_space.high[obs_self_size:obs_self_size+self.clip_neighbor_space_length]
@@ -152,9 +152,11 @@ class QuadrotorEnvMulti(gym.Env):
     def extend_obs_space(self, obs):
         obs_neighbors = []
         for i in range(len(self.envs)):
-            observs = np.concatenate((self.envs[i].dynamics.pos, self.envs[i].dynamics.vel))
+            observs = np.concatenate((self.envs[i].dynamics.pos, self.envs[i].dynamics.vel, self.envs[i].goal))
             obs_neighbor = np.array([list(self.envs[j].dynamics.pos) + list(self.envs[j].dynamics.vel) for j in range(len(self.envs)) if j != i])
-            obs_neighbor_rel = obs_neighbor - observs
+            obs_neighbor_rel = obs_neighbor - observs[:6]  # b/c observs also contains goals as last 3 entries
+            goals = np.stack([self.envs[j].goal for j in range(len(self.envs)) if j != i])
+            obs_neighbor_rel = np.concatenate((obs_neighbor_rel, goals), axis=1)
             obs_neighbors.append(obs_neighbor_rel.reshape(-1))
         obs_neighbors = np.stack(obs_neighbors)
 

--- a/gym_art/quadrotor_multi/quadrotor_multi.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi.py
@@ -170,7 +170,7 @@ class QuadrotorEnvMulti(gym.Env):
              j != i])
         obs_neighbor_rel = obs_neighbor - observs
         if self.swarm_obs == 'pos_vel_goals':  # include relative goal info of neighbors
-            goals_rel = np.stack([self.envs[j].goal for j in range(len(self.envs)) if j != i]) - observs[:3]
+            goals_rel = np.stack([self.envs[j].goal for j in range(len(self.envs)) if j != i]) - observs[:3]  # subtract pos of current drone
             obs_neighbor_rel = np.concatenate((obs_neighbor_rel, goals_rel), axis=1)
         return obs_neighbor_rel
 

--- a/gym_art/quadrotor_multi/quadrotor_multi.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi.py
@@ -150,9 +150,9 @@ class QuadrotorEnvMulti(gym.Env):
 
     def extend_obs_space(self, obs):
         obs_neighbors = []
-        for i in range(len(obs)):
-            observs = obs[i]
-            obs_neighbor = np.array([obs[j][:self.neighbor_obs_size] for j in range(len(obs)) if j != i])
+        for i in range(len(self.envs)):
+            observs = np.concatenate((self.envs[i].dynamics.pos, self.envs[i].dynamics.vel, self.envs[i].dynamics.rot.flatten(), self.envs[i].dynamics.omega))
+            obs_neighbor = np.array([list(self.envs[j].dynamics.pos) + list(self.envs[j].dynamics.vel) for j in range(len(self.envs)) if j != i])
             obs_neighbor_rel = obs_neighbor - observs[:self.neighbor_obs_size]
             obs_neighbors.append(obs_neighbor_rel.reshape(-1))
         obs_neighbors = np.stack(obs_neighbors)

--- a/gym_art/quadrotor_multi/quadrotor_multi.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi.py
@@ -151,9 +151,9 @@ class QuadrotorEnvMulti(gym.Env):
     def extend_obs_space(self, obs):
         obs_neighbors = []
         for i in range(len(self.envs)):
-            observs = np.concatenate((self.envs[i].dynamics.pos, self.envs[i].dynamics.vel, self.envs[i].dynamics.rot.flatten(), self.envs[i].dynamics.omega))
+            observs = np.concatenate((self.envs[i].dynamics.pos, self.envs[i].dynamics.vel))
             obs_neighbor = np.array([list(self.envs[j].dynamics.pos) + list(self.envs[j].dynamics.vel) for j in range(len(self.envs)) if j != i])
-            obs_neighbor_rel = obs_neighbor - observs[:self.neighbor_obs_size]
+            obs_neighbor_rel = obs_neighbor - observs
             obs_neighbors.append(obs_neighbor_rel.reshape(-1))
         obs_neighbors = np.stack(obs_neighbors)
 

--- a/gym_art/quadrotor_multi/quadrotor_single.py
+++ b/gym_art/quadrotor_multi/quadrotor_single.py
@@ -689,7 +689,7 @@ class QuadrotorSingle:
                  sim_steps=2,
                  obs_repr="xyz_vxyz_R_omega", ep_time=7, obstacles_num=0, room_length=10, room_width=10, room_height=10, init_random_state=False,
                  rew_coeff=None, sense_noise=None, verbose=False, gravity=GRAV,
-                 t2w_std=0.005, t2t_std=0.0005, excite=False, dynamics_simplification=False, use_numba=False, swarm_obs='default', num_agents=1,quads_settle=False,
+                 t2w_std=0.005, t2t_std=0.0005, excite=False, dynamics_simplification=False, use_numba=False, swarm_obs='none', num_agents=1,quads_settle=False,
                  quads_settle_range_meters=1.0, quads_vel_reward_out_range=0.8,
                  view_mode='local', obstacle_mode='no_obstacles', obstacle_num=0, num_use_neighbor_obs=0):
         np.seterr(under='ignore')
@@ -968,9 +968,9 @@ class QuadrotorSingle:
         self.obs_comp_sizes = [self.obs_space_low_high[name][1].size for name in self.obs_comp_names]
 
         obs_comps = self.obs_repr.split("_")
-        if self.swarm_obs == 'extend' and self.num_agents > 1:
+        if self.swarm_obs == 'pos_vel' and self.num_agents > 1:
             obs_comps = obs_comps + (['rxyz'] + ['rvxyz']) * self.num_use_neighbor_obs
-        elif self.swarm_obs == 'extend+' and self.num_agents > 1:
+        elif self.swarm_obs == 'pos_vel_goals' and self.num_agents > 1:
             obs_comps = obs_comps + (['rxyz'] + ['rvxyz'] + ['goal']) * self.num_use_neighbor_obs
         if self.obstacle_mode != 'no_obstacles' and self.obstacle_num > 0:
             obs_comps = obs_comps + (['roxyz'] + ['rovxyz']) * (self.obstacle_num)

--- a/gym_art/quadrotor_multi/quadrotor_single.py
+++ b/gym_art/quadrotor_multi/quadrotor_single.py
@@ -689,7 +689,7 @@ class QuadrotorSingle:
                  sim_steps=2,
                  obs_repr="xyz_vxyz_R_omega", ep_time=7, obstacles_num=0, room_length=10, room_width=10, room_height=10, init_random_state=False,
                  rew_coeff=None, sense_noise=None, verbose=False, gravity=GRAV,
-                 t2w_std=0.005, t2t_std=0.0005, excite=False, dynamics_simplification=False, use_numba=False, swarm_obs=False, num_agents=1,quads_settle=False,
+                 t2w_std=0.005, t2t_std=0.0005, excite=False, dynamics_simplification=False, use_numba=False, swarm_obs='default', num_agents=1,quads_settle=False,
                  quads_settle_range_meters=1.0, quads_vel_reward_out_range=0.8,
                  view_mode='local', obstacle_mode='no_obstacles', obstacle_num=0):
         np.seterr(under='ignore')
@@ -967,7 +967,9 @@ class QuadrotorSingle:
         self.obs_comp_sizes = [self.obs_space_low_high[name][1].size for name in self.obs_comp_names]
 
         obs_comps = self.obs_repr.split("_")
-        if self.swarm_obs and self.num_agents > 1:
+        if self.swarm_obs == 'extend' and self.num_agents > 1:
+            obs_comps = obs_comps + (['rxyz'] + ['rvxyz']) * (self.num_agents-1)
+        elif self.swarm_obs == 'extend+' and self.num_agents > 1:
             obs_comps = obs_comps + (['rxyz'] + ['rvxyz'] + ['goal']) * (self.num_agents-1)
         if self.obstacle_mode != 'no_obstacles' and self.obstacle_num > 0:
             obs_comps = obs_comps + (['roxyz'] + ['rovxyz']) * (self.obstacle_num)

--- a/gym_art/quadrotor_multi/quadrotor_single.py
+++ b/gym_art/quadrotor_multi/quadrotor_single.py
@@ -961,14 +961,14 @@ class QuadrotorSingle:
             "rvxyz": [-2.0 * self.dynamics.vxyz_max * np.ones(3), 2.0 * self.dynamics.vxyz_max * np.ones(3)], # rvxyz stands for relative velocity between quadrotors
             "roxyz": [-(self.room_box[1] - self.room_box[0]), self.room_box[1] - self.room_box[0]], # roxyz stands for relative pos between quadrotor and obstacle
             "rovxyz": [-20.0 * np.ones(3), 20.0 * np.ones(3)], # rovxyz stands for relative velocity between quadrotor and obstacle
-
+            "goal": [-(self.room_box[1] - self.room_box[0]), self.room_box[1] - self.room_box[0]],
         }
         self.obs_comp_names = list(self.obs_space_low_high.keys())
         self.obs_comp_sizes = [self.obs_space_low_high[name][1].size for name in self.obs_comp_names]
 
         obs_comps = self.obs_repr.split("_")
         if self.swarm_obs and self.num_agents > 1:
-            obs_comps = obs_comps + (['rxyz'] + ['rvxyz']) * (self.num_agents-1)
+            obs_comps = obs_comps + (['rxyz'] + ['rvxyz'] + ['goal']) * (self.num_agents-1)
         if self.obstacle_mode != 'no_obstacles' and self.obstacle_num > 0:
             obs_comps = obs_comps + (['roxyz'] + ['rovxyz']) * (self.obstacle_num)
 
@@ -1047,6 +1047,7 @@ class QuadrotorSingle:
             "act_filtered": [self.dynamics.thrust_cmds_damp],
             "act_torque": [self.dynamics.prop_ccw * self.dynamics.thrust_cmds_damp],
             "torque": [self.dynamics.torque],
+            "goal": [self.goal]
         }
 
         dyn_params = {


### PR DESCRIPTION
**Extending Obs Space**
obs_space = 'default' would be the equivalent of having extend_obs=False from the previous version of the code. 'extend' now means include neighboring drones' relative pos/vel, and 'extend+' means include neighboring drones relative pos/vel + their respective goals. 

**Changes to quad_scenarios**

- Swarm vs swarm: Fixed an issue where the goals weren't swapping. Also, I've made the goals swap on a timer, regardless of whether or not the drones have settled. Currently we have no guarantee that the drones will settle especially in the mixed scenario, so we lose valuable collisions training data by only swapping when they settle. 
- Lissajous: The drones were constantly running into one of the walls trying to follow the lissajous curve, so I've adjusted the starting position of the goal to address this. 
- I've also moved the min and max formation sizes for all scenarios to be higher because they were too small imo.