### PR TITLE
Smooth the Global Camera

### DIFF
--- a/gym_art/quadrotor_multi/quad_scenarios.py
+++ b/gym_art/quadrotor_multi/quad_scenarios.py
@@ -141,7 +141,8 @@ class QuadrotorScenario_Dynamic_Goal(QuadrotorScenario):
             box_size = self.envs[0].box
             x, y = np.random.uniform(low=-box_size, high=box_size, size=(2,)) + self.formation_center[:2]
             z = np.random.uniform(low=-0.5 * box_size, high=0.5 * box_size) + self.formation_center[2]
-            z = max(0.25, z)
+            z_lower_bound = np.ceil(np.sqrt(self.num_agents)) * self.formation_size + 0.25
+            z = max(z_lower_bound, z)
             self.formation_center = np.array([x, y, z])
             self.goals = self.generate_goals(num_agents=self.num_agents, formation_center=self.formation_center)
             for i, env in enumerate(self.envs):

--- a/gym_art/quadrotor_multi/quadrotor_multi.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi.py
@@ -229,7 +229,8 @@ class QuadrotorEnvMulti(gym.Env):
             self.scene = Quadrotor3DSceneMulti(
                 models=models,
                 w=640, h=480, resizable=True, obstacles=self.obstacles, viewpoint=self.envs[0].viewpoint,
-                obstacle_mode=self.obstacle_mode, room_dims=self.room_dims, num_agents=self.num_agents
+                obstacle_mode=self.obstacle_mode, room_dims=self.room_dims, num_agents=self.num_agents,
+                render_speed=self.render_speed
             )
         else:
             self.scene.update_models(models)

--- a/gym_art/quadrotor_multi/quadrotor_multi.py
+++ b/gym_art/quadrotor_multi/quadrotor_multi.py
@@ -144,10 +144,7 @@ class QuadrotorEnvMulti(gym.Env):
         self.simulation_start_time = 0
         self.frames_since_last_render = self.render_skip_frames = 0
         self.render_every_nth_frame = 1
-        self.render_speed = 1.0  # set to below 1 
-        
-        
-  slowmo, higher than 1 for fast forward (if simulator can keep up)
+        self.render_speed = 1.0  # set to below 1 slowmo, higher than 1 for fast forward (if simulator can keep up)
 
         # measuring the total number of pairwise collisions per episode
         self.collisions_per_episode = 0


### PR DESCRIPTION
It's based on suggestions from @alex-petrenko . 
1. Smooth the global camera. When we hold the key, the view should keep changing.
2. The global camera should remember the configuration of view angle.
3. The global camera should not follow the goals, only initialize to look at the goals at the beginning of the episode. (Although I think it might not suit for pursuit-evasion scenarios)
4. Use another button to change the camera focus manually, i.e. when we change the positions of the goals.
Details on slack: https://usc-ai.slack.com/archives/CR0SVC683/p1611300227030600?thread_ts=1611299900.028600&cid=CR0SVC683
-------------------------------------------------------------------------------------
New functions:
key.J: increase the **Z** pos of the global camera.
key.N: Decrease the **Z** pos.
key.B: Decrease the **Y** pos of the global camera.
key.M: Increase the **Y** pos.